### PR TITLE
🔖 release/v2.0.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: tmdb_api
 description: Dart client-side API package for TMDB.org API (https://www.themoviedb.org/).
-version: 2.0.0-nullsafety
+version: 2.0.0
 # author: Ratakondala Arun<ratakondalaarun@gmail.com>
 homepage: https://github.com/RatakondalaArun/tmdb_api.git
 


### PR DESCRIPTION
- Null safety to stable
- Require Dart SDK to >=2.14.0 <3.0.0
- Fixed lint warnings
- Upgraded dependencies