### PR TITLE
rm/deprecated

### DIFF
--- a/lib/utils/tmdb_exceptions.dart
+++ b/lib/utils/tmdb_exceptions.dart
@@ -12,35 +12,3 @@ class TMDBException implements Exception {
     return 'TMDBException() thrown message:$message | at source:$source | help:$help';
   }
 }
-
-///Encountered a null value.
-@Deprecated('Removed infavor of nullsafety. Will be removed in v2.1.0')
-class NullValueException extends TMDBException {
-  @Deprecated('Removed infavor of nullsafety. Will be removed in v2.1.0')
-  NullValueException(
-    String message, {
-    String? source,
-    String help = 'try to pass a non null values',
-  }) : super(message, source: source, help: help);
-
-  @override
-  String toString() {
-    return 'NullValueException() thrown message:$message | at source:$source | help:$help';
-  }
-}
-
-///When constrains are not meet
-@Deprecated('Infavor of ArgumentException. Will be removed in v2.1.0')
-class InvalidDataException extends TMDBException {
-  @Deprecated('Infavor of ArgumentException. Will be removed in v2.1.0')
-  InvalidDataException(
-    String message, {
-    String? source,
-    String help = 'Data is invalid',
-  }) : super(message, source: source, help: help);
-
-  @override
-  String toString() {
-    return 'InvalidDataException() thrown message:$message | at source:$source | help:$help';
-  }
-}


### PR DESCRIPTION
Removed 

- [`NullValueException`](https://github.com/RatakondalaArun/tmdb_api/blob/690623e286826addc2a3b02ab3db91f5cd3bbd54/lib/utils/tmdb_exceptions.dart#L17-L30)
-  [`InvalidDataException`](https://github.com/RatakondalaArun/tmdb_api/blob/690623e286826addc2a3b02ab3db91f5cd3bbd54/lib/utils/tmdb_exceptions.dart#L32-L46)

- closes #77 