### PR TITLE
Add language query to trending

### DIFF
--- a/lib/versions/v3/category/trending.dart
+++ b/lib/versions/v3/category/trending.dart
@@ -27,14 +27,17 @@ class Trending extends Category<V3> {
   ///Map result = await tmdb.v3.trending.getTrending(mediaType = MediaType.all,timeWindow = TimeWindow.day);
   /// ```
   ///
-  Future<Map> getTrending({
-    MediaType mediaType = MediaType.all,
-    TimeWindow timeWindow = TimeWindow.day,
-    int page = 1,
-  }) {
+  Future<Map> getTrending(
+      {MediaType mediaType = MediaType.all,
+      TimeWindow timeWindow = TimeWindow.day,
+      int page = 1,
+      String? language}) {
     return _v._query(
       '$_endPoint/${_getMediaType(mediaType)}/${_getTimeWindow(timeWindow)}',
-      optionalQueries: ['page=$page'],
+      optionalQueries: [
+        'page=$page',
+        'language=${language ?? _v._tmdb.defaultLanguage}'
+      ],
     );
   }
 


### PR DESCRIPTION
The get-trending request is supporting the language query. This is just not described in their docu.
Example: https://api.themoviedb.org/3/trending/movie/week?language=de&api_key=xxx