### PR TITLE
POST/DELETE/PUT endpoint requests now include the dataBody via Map

### DIFF
--- a/lib/versions/v4.dart
+++ b/lib/versions/v4.dart
@@ -50,17 +50,20 @@ class V4 extends Version {
         print('Making a post request to $url');
         response = await dio.postUri(
           url,
+          data: postBody,
           options: Options(headers: postHeaders),
         );
       } else if (method == HttpMethod.delete) {
         //DELETE request
         response = await dio.deleteUri(
           url,
+          data: deleteBody,
           options: Options(headers: deleteHeaders),
         );
       } else if (method == HttpMethod.put) {
         response = await dio.putUri(
           url,
+          data: postBody,
           options: Options(headers: postHeaders),
         );
       } else {


### PR DESCRIPTION
The v4 POST/PUT & DELETE TMDB API endpoints are missing the data body parameters resulting in HTTP 400 error responses from the TMDB API. This patches the http.dio* methods to include the bodies.