### PR TITLE
Fix markAsFavorite and addToWatchList

### DIFF
--- a/lib/versions/v3.dart
+++ b/lib/versions/v3.dart
@@ -91,7 +91,7 @@ class V3 extends Version {
     String endPoint, {
     HttpMethod method = HttpMethod.get,
     List<String>? optionalQueries,
-    Map<String, String>? postBody,
+    Map<String, dynamic>? postBody,
     Map<String, String>? deleteBody,
     Map<String, String>? postHeaders,
   }) async {
@@ -135,6 +135,8 @@ class V3 extends Version {
   }
 
   String _optionalQueries(List<String>? queries, String currentQuery) {
-    return (queries == null || queries.isEmpty) ? currentQuery : '$currentQuery&${queries.join('&')}';
+    return (queries == null || queries.isEmpty)
+        ? currentQuery
+        : '$currentQuery&${queries.join('&')}';
   }
 }

--- a/lib/versions/v3/category/account.dart
+++ b/lib/versions/v3/category/account.dart
@@ -267,7 +267,11 @@ class Account extends Category<V3> {
       '$_endPoint/$accountId/favorite',
       method: HttpMethod.post,
       optionalQueries: ['session_id=$sessionId'],
-      postBody: {'media_type': type, 'media_id': '$mediaId', 'favorite': '$isFavorite'},
+      postBody: {
+        'media_type': type,
+        'media_id': mediaId,
+        'favorite': isFavorite,
+      },
     );
   }
 

--- a/lib/versions/v3/category/account.dart
+++ b/lib/versions/v3/category/account.dart
@@ -664,8 +664,8 @@ class Account extends Category<V3> {
       optionalQueries: ['session_id=$sessionId'],
       postBody: {
         'media_type': type,
-        'media_id': '$mediaId',
-        'watchlist': '$shouldAdd',
+        'media_id': mediaId,
+        'watchlist': shouldAdd,
       },
     );
   }


### PR DESCRIPTION
### Description

This PR resolves an issue with the `markAsFavorite` and `addToWatchlist` methods in which the API call does not correctly handle false values in the request body, leading to a silent failure when attempting to mark an item as not favorite.

### Issue Details

The markAsFavorite method calls a private `_query` method, which is used to send a POST request with a body parameter of type `Map<String, String>`. This type constraint converts all values in the map to strings, including boolean values. While the server accepts true as a string, it does not accept false in this format, causing the request to succeed without applying the change when false is sent.

### Solution

To fix this issue, the POST body parameter in `_query` has been changed from `Map<String, String>` to `Map<String, dynamic>`. This allows boolean values to be sent in their correct format, ensuring that both true and false values are correctly processed by the server.